### PR TITLE
Added support for Python versions 3.8 - 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.4.0](https://github.com/dataiku/dss-plugin-nlp-summarization/releases/tag/v1.4.0) - Python compatibility - 2023-04
+
+- ✨ Added support for Python versions 3.8, 3.9, 3.10, 3.11
+
 ## [Version 1.3.0](https://github.com/dataiku/dss-plugin-nlp-summarization/releases/tag/v1.3.0) - UIF & Py3 Compat - 2022-06
 
 - ✨ Add UIF and Python3 compatibility

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,6 +1,15 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON37"],
+  "acceptedPythonInterpreters": [
+    "PYTHON27",
+    "PYTHON36",
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311"
+  ],
   "forceConda": false,
   "installCorePackages": true,
+  "corePackagesSet": "AUTO",
   "installJupyterSupport": false
 }

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,4 +1,6 @@
-nltk==3.4.5
-sumy==0.8.1
+nltk==3.4.5; python_version < '3.8'
+nltk==3.8.1; python_version >= '3.8'
+sumy==0.8.1; python_version < '3.8'
+sumy==0.11.0; python_version >= '3.8'
 pycountry==19.8.18
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "text-summarization",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "meta": {
         "label": "Text Summarization",
         "category": "Natural Language Processing",


### PR DESCRIPTION
[sc-132159]

Added Python 3.8, 3.9, 3.10, 3.11

---

The `nltk` and `sumy` libraries needed bumping for the newer versions of Python. 
- I only bumped them for newer versions of Python that this plugin did not support before now
- According to their docs we could bump them for older Pythons as well, but I left them to be 100% sure of not changing anything for users who are on older versions of Python
    - latest `nltk` says it supports Python 3.7
    - latest `sumy`  says it supports Python 3.6

---

Tested this by: 
- Created my own project https://staging-design.qa.managedinstances.dkucloud-dev.com/projects/PLUGINTESTNLPSUMMARIZATION/
- Tested on Python versions 2.7, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
- Ran the plugin with methods `textrank` and `lsa`
- Compared the outputs by eye
- The `klsum` method took 45 mins to run, so I only ran it on Python 2.7 and 3.11
- The `number of sentences` parameter looks trivial, so I only tested it on `textrank` and `lsa`, for Python 2.7 and 3.11