### PR TITLE
chore: update nltk and supported Python versions to fix CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Version 2.0.0](https://github.com/dataiku/dss-plugin-nlp-summarization/releases/tag/v2.0.0) - 2026-04
+
+- Updated nltk to the most secure version available to fix several CVEs. Use Python 3.10 and up to have all available security updates
+- Removed support for Python 3.7 and lower since they don't have a secure nltk wheel available
+- Added support for Python 3.12
+
 ## [Version 1.4.1](https://github.com/dataiku/dss-plugin-nlp-summarization/releases/tag/v1.4.1) - 2025-12
 
 - Updated warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Updated nltk to the most secure version available to fix several CVEs. Use Python 3.10 and up to have all available security updates
 - Removed support for Python 3.7 and lower since they don't have a secure nltk wheel available
-- Added support for Python 3.12
+- Added support for Python 3.12, 3.13 and 3.14
 
 ## [Version 1.4.1](https://github.com/dataiku/dss-plugin-nlp-summarization/releases/tag/v1.4.1) - 2025-12
 

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -4,7 +4,9 @@
     "PYTHON39",
     "PYTHON310",
     "PYTHON311",
-    "PYTHON312"
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
   ],
   "forceConda": false,
   "installCorePackages": true,

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,12 +1,10 @@
 {
   "acceptedPythonInterpreters": [
-    "PYTHON27",
-    "PYTHON36",
-    "PYTHON37",
     "PYTHON38",
     "PYTHON39",
     "PYTHON310",
-    "PYTHON311"
+    "PYTHON311",
+    "PYTHON312"
   ],
   "forceConda": false,
   "installCorePackages": true,

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,6 +1,7 @@
 nltk==3.9.1; python_version == '3.8'
 nltk==3.9.2; python_version == '3.9'
 nltk==3.9.4; python_version >= '3.10'
+packaging; python_version >= '3.12'
 sumy==0.8.1; python_version < '3.8'
 sumy==0.11.0; python_version >= '3.8'
 pycountry==19.8.18

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,6 +1,6 @@
-nltk==3.4.5; python_version < '3.8'
-nltk==3.8.1; python_version >= '3.8'
+nltk==3.9.1; python_version == '3.8'
+nltk==3.9.2; python_version == '3.9'
+nltk==3.9.4; python_version >= '3.10'
 sumy==0.8.1; python_version < '3.8'
 sumy==0.11.0; python_version >= '3.8'
 pycountry==19.8.18
-

--- a/code-env/python/spec/resources_init.py
+++ b/code-env/python/spec/resources_init.py
@@ -13,4 +13,4 @@ clear_all_env_vars()
 # Download punkt resources to the NLTK_HOME cache directory
 set_env_path("NLTK_HOME", "nltk_data")
 cache_folder = os.getenv("NLTK_HOME")
-nltk.download('punkt', download_dir=cache_folder)
+nltk.download('punkt_tab', download_dir=cache_folder)

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "text-summarization",
-    "version": "1.4.1",
+    "version": "2.0.0",
     "meta": {
         "label": "Text Summarization",
         "category": "NLP",


### PR DESCRIPTION
This PR:
- updates `ntlk` to the most secure version available
- removes support for Python versions with no secure wheel, that is Python 3.7 and lower
- adds support for Python 3.12, 3.13 and 3.14